### PR TITLE
Added fallback to using a direct deb package install.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,12 @@ enroot_ubuntu_repo: none
 enroot_packages:
   - enroot
   - 'enroot+caps'
+
 enroot_package_state: present
+
+enroot_deb_packages:
+  - 'https://github.com/NVIDIA/enroot/releases/download/v2.0.1/enroot_2.0.1-1_amd64.deb'
+  - 'https://github.com/NVIDIA/enroot/releases/download/v2.0.1/enroot+caps_2.0.1-1_amd64.deb'
 
 # a block of lines to add to enroot.conf
 enroot_config: ''

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -3,15 +3,25 @@
   apt_key:
     url: "{{ enroot_ubuntu_repo_key_url }}"
     id: "{{ enroot_ubuntu_repo_key_id }}"
+  when: enroot_ubuntu_repo|bool
 
 - name: repo
   apt_repository:
     repo: "{{ enroot_ubuntu_repo }}"
+  when: enroot_ubuntu_repo|bool
 
 - name: enroot packages
   apt:
     name: "{{ enroot_packages }}"
     state: "{{ enroot_package_state }}"
+  when: enroot_ubuntu_repo|bool
+
+- name: enroot deb packages
+  apt:
+    deb: "{{ item }}"
+    state: "{{ enroot_package_state }}"
+  with_items: "{{ enroot_deb_packages }}"
+  when: not enroot_ubuntu_repo|bool
 
 - name: enroot dependency packages
   apt:


### PR DESCRIPTION
Dependent on the following links existing (do not merge until so)...

https://github.com/NVIDIA/enroot/releases/download/v2.0.1/enroot_2.0.1-1_amd64.deb
https://github.com/NVIDIA/enroot/releases/download/v2.0.1/enroot+caps_2.0.1-1_amd64.deb