### PR TITLE
Fix some ansible filters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,15 +1,14 @@
 ---
-# FIXME: replace with official repo when available
+# Install option 1: provide repo, key, and list of packages
 enroot_ubuntu_repo_key_url: none
 enroot_ubuntu_repo_key_id: none
 enroot_ubuntu_repo: none
-
 enroot_packages:
   - enroot
   - 'enroot+caps'
-
 enroot_package_state: present
 
+# Install option 2 (default): provide direct URLs to debs
 enroot_deb_packages:
   - 'https://github.com/NVIDIA/enroot/releases/download/v2.0.1/enroot_2.0.1-1_amd64.deb'
   - 'https://github.com/NVIDIA/enroot/releases/download/v2.0.1/enroot+caps_2.0.1-1_amd64.deb'

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -3,25 +3,25 @@
   apt_key:
     url: "{{ enroot_ubuntu_repo_key_url }}"
     id: "{{ enroot_ubuntu_repo_key_id }}"
-  when: enroot_ubuntu_repo|bool
+  when: enroot_ubuntu_repo == none
 
 - name: repo
   apt_repository:
     repo: "{{ enroot_ubuntu_repo }}"
-  when: enroot_ubuntu_repo|bool
+  when: enroot_ubuntu_repo == none
 
 - name: enroot packages
   apt:
     name: "{{ enroot_packages }}"
     state: "{{ enroot_package_state }}"
-  when: enroot_ubuntu_repo|bool
+  when: enroot_ubuntu_repo == none
 
 - name: enroot deb packages
   apt:
     deb: "{{ item }}"
     state: "{{ enroot_package_state }}"
   with_items: "{{ enroot_deb_packages }}"
-  when: not enroot_ubuntu_repo|bool
+  when: enroot_ubuntu_repo != none
 
 - name: enroot dependency packages
   apt:


### PR DESCRIPTION
It's not clear to me how these filters ever worked.
```
root@24153bfd5d9a:/# ansible --version
ansible 2.5.1
                                                                                                                                                          
root@24153bfd5d9a:/# ansible localhost -e 'foo=bar' -m debug -a 'var=foo|bool'
localhost | SUCCESS => {
    "foo|bool": false
}
```