### PR TITLE
Support install on RHEL/CentOS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,17 +1,27 @@
 ---
-# Install option 1: provide repo, key, and list of packages
-enroot_ubuntu_repo_key_url: none
-enroot_ubuntu_repo_key_id: none
-enroot_ubuntu_repo: none
+# Names of packages to install
 enroot_packages:
   - enroot
   - 'enroot+caps'
 enroot_package_state: present
 
-# Install option 2 (default): provide direct URLs to debs
+# Install option 1 (default): provide direct URLs to debs or rpms
 enroot_deb_packages:
   - 'https://github.com/NVIDIA/enroot/releases/download/v3.0.2/enroot_3.0.2-1_amd64.deb'
   - 'https://github.com/NVIDIA/enroot/releases/download/v3.0.2/enroot+caps_3.0.2-1_amd64.deb'
+enroot_rpm_packages:
+  - 'https://github.com/NVIDIA/enroot/releases/download/v3.0.2/enroot-3.0.2-1.el7.x86_64.rpm'
+  - 'https://github.com/NVIDIA/enroot/releases/download/v3.0.2/enroot+caps-3.0.2-1.el7.x86_64.rpm'
+
+# Install option 2: provide repo, key, and list of packages
+# No default repositories exist, so this will need to refer to repos you set up
+#
+#enroot_ubuntu_repo_key_url: ''
+#enroot_ubuntu_repo_key_id: ''
+#enroot_ubuntu_repo: ''
+#enroot_rhel_repo_gpgkey: ''
+#enroot_rhel_repo: ''
+
 
 # a block of lines to add to enroot.conf
 enroot_config: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
+epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+
 # Names of packages to install
 enroot_packages:
   - enroot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,10 @@
   include_tasks: ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
+- name: rhel tasks
+  include_tasks: rhel.yml
+  when: ansible_os_family == 'RedHat'
+
 - name: install bash completions
   file:
     path: /etc/bash_completion.d/enroot.bash_completion

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   when: ansible_distribution == 'Ubuntu'
 
 - name: rhel tasks
-  include_tasks: rhel.yml
+  include_tasks: redhat.yml
   when: ansible_os_family == 'RedHat'
 
 - name: install bash completions

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -7,7 +7,8 @@
   - "bash-completion"
 
 - name: set up yum repository (if defined)
-  yum_repository: enroot
+  yum_repository:
+    name: enroot
     baseurl: "{{ enroot_rhel_repo }}"
     gpgkey: "{{ enroot_rhel_repo_gpgkey }}"
   when: enroot_rhel_repo is defined

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,6 +2,7 @@
 - name: install epel repository
   yum_repository:
     name: epel
+    description: epel
     baseurl: "{{ epel_baseurl }}"
     gpgkey: "{{ epel_gpgkey }}"
 
@@ -18,6 +19,7 @@
 - name: set up yum repository (if defined)
   yum_repository:
     name: enroot
+    description: enroot
     baseurl: "{{ enroot_rhel_repo }}"
     gpgkey: "{{ enroot_rhel_repo_gpgkey }}"
   when: enroot_rhel_repo is defined

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,27 @@
+---
+- name: install enroot dependency packages
+  yum:
+    name: "{{ item }}"
+  with_items:
+  - "pigz"
+  - "bash-completion"
+
+- name: set up yum repository (if defined)
+  yum_repository: enroot
+    baseurl: "{{ enroot_rhel_repo }}"
+    gpgkey: "{{ enroot_rhel_repo_gpgkey }}"
+  when: enroot_rhel_repo is defined
+
+- name: install packages from repo (if defined)
+  yum:
+    name: "{{ item }}"
+    state: "{{ enroot_package_state }}"
+  with_items: "{{ enroot_packages }}"
+  when: enroot_rhel_repo is defined
+
+- name: install rpm packages directly if no repo is defined
+  yum:
+    name: "{{ item }}"
+    state: "{{ enroot_package_state }}"
+  with_items: "{{ enroot_rpm_packages }}"
+  when: enroot_rhel_repo is not defined

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,10 +10,10 @@
   yum:
     name: "{{ item }}"
   with_items:
-  - "pigz"
   - "bash-completion"
   - "jq"
   - "parallel"
+  - "pigz"
   - "zstd"
 
 - name: set up yum repository (if defined)

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,10 +1,19 @@
 ---
+- name: install epel repository
+  yum_repository:
+    name: epel
+    baseurl: "{{ epel_baseurl }}"
+    gpgkey: "{{ epel_gpgkey }}"
+
 - name: install enroot dependency packages
   yum:
     name: "{{ item }}"
   with_items:
   - "pigz"
   - "bash-completion"
+  - "jq"
+  - "parallel"
+  - "zstd"
 
 - name: set up yum repository (if defined)
   yum_repository:

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,30 +1,32 @@
 ---
+- name: enroot dependency packages
+  apt:
+    name:
+      - bash-completion
+      - pigz
+
 - name: repo key
   apt_key:
     url: "{{ enroot_ubuntu_repo_key_url }}"
     id: "{{ enroot_ubuntu_repo_key_id }}"
-  when: enroot_ubuntu_repo == none
+  when: enroot_ubuntu_repo is defined
 
 - name: repo
   apt_repository:
     repo: "{{ enroot_ubuntu_repo }}"
-  when: enroot_ubuntu_repo == none
+  when: enroot_ubuntu_repo is defined
 
 - name: enroot packages
   apt:
     name: "{{ enroot_packages }}"
     state: "{{ enroot_package_state }}"
-  when: enroot_ubuntu_repo == none
+  when: enroot_ubuntu_repo is defined
 
 - name: enroot deb packages
   apt:
     deb: "{{ item }}"
     state: "{{ enroot_package_state }}"
   with_items: "{{ enroot_deb_packages }}"
-  when: enroot_ubuntu_repo != none
+  when: enroot_ubuntu_repo is not defined
 
-- name: enroot dependency packages
-  apt:
-    name:
-      - bash-completion
-      - pigz
+


### PR DESCRIPTION
* Add support for installing enroot on RHEL/CentOS via this role
* Refactor the role slightly to use idioms more common in DeepOps

## Test plan

Imported modified role into DeepOps and ran cluster turnup with CentOS VMs, observed that enroot was installed correctly.