### PR TITLE
Update redhat.yml

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,10 +1,9 @@
 ---
 - name: install epel repository
-  yum_repository:
-    name: epel
-    description: epel
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
+  yum:
+    name: 
+      - "epel-release"
+    state: latest
 
 - name: install enroot dependency packages
   yum:


### PR DESCRIPTION
modify epel repo creation to allow for RHEL/CentOS 7 & 8 flexibility. Changed from static URL to yum install epel-release method.