### PR TITLE
Remove static epel url & key for RHEL 7 & 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-
 # Names of packages to install
 enroot_packages:
   - enroot


### PR DESCRIPTION
no longer required with 'yum install epel-release' method in tasks/install-redhat.yml