### PR TITLE
Install EPEL via epel-release package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-epel_baseurl: "https://download.fedoraproject.org/pub/epel/$releasever/$basearch/"
-epel_gpgkey: "https://epel.mirror.constant.com//RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-
 # Names of packages to install
 enroot_packages:
   - enroot

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,10 +1,8 @@
 ---
 - name: install epel repository
-  yum_repository:
-    name: epel
-    description: epel
-    baseurl: "{{ epel_baseurl }}"
-    gpgkey: "{{ epel_gpgkey }}"
+  package:
+    name: epel-release
+    state: present
 
 - name: install enroot dependency packages
   yum:


### PR DESCRIPTION
This should allow installation with CentOS/RHEL 8, which don't use the same URL scheme for EPEL.