### PR TITLE
Use Fedora EPEL package to enable EPEL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ enroot_rpm_packages:
   - 'https://github.com/NVIDIA/enroot/releases/download/v3.2.0/enroot-3.2.0-1.el7.x86_64.rpm'
   - 'https://github.com/NVIDIA/enroot/releases/download/v3.2.0/enroot+caps-3.2.0-1.el7.x86_64.rpm'
 
+epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+
 # Install option 2: provide repo, key, and list of packages
 # No default repositories exist, so this will need to refer to repos you set up
 #

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: install epel repository
   package:
-    name: epel-release
+    name: "{{ epel_package }}"
     state: present
 
 - name: install enroot dependency packages


### PR DESCRIPTION
Making this consistent with DeepOps so everything works on RHEL and can
be configured with the same var (`epel_package`)