### PR TITLE
On Red Hat systems, add necessary kernel command line options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,8 @@ enroot_config: ''
 enroot_environ_config_files: []  # filenames should end with .env
 enroot_hook_config_files: []     # filenames should end with .sh
 enroot_mount_config_files: []    # filenames should end with .fstab
+
+# Should we configure kernel on RedHat systems and reboot?
+enroot_configure_kernel_options: true
+enroot_configure_kernel_options_versions: "ALL"
+enroot_reboot_timeout: 900

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ enroot_mount_config_files: []    # filenames should end with .fstab
 enroot_configure_kernel_options: true
 enroot_configure_kernel_options_versions: "ALL"
 enroot_reboot_timeout: 900
+enroot_max_user_namespaces: 65536
+enroot_max_mnt_namespaces: 65536

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reboot node
+  reboot:
+    reboot_timeout: "{{ enroot_reboot_timeout }}" 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -35,3 +35,29 @@
     state: "{{ enroot_package_state }}"
   with_items: "{{ enroot_rpm_packages }}"
   when: enroot_rhel_repo is not defined
+
+- name: check if kernel unpriv enabled
+  shell: "cat /proc/cmdline | grep 'namespace.unpriv_enable=1'"
+  register: kernel_unpriv_enable
+  failed_when: kernel_unpriv_enable.rc == 127
+
+- name: check if user namespaces enabled
+  shell: "cat /proc/cmdline | grep 'user_namespace.enable=1'"
+  register: kernel_user_namespace
+  failed_when: kernel_user_namespace.rc == 127
+
+- name: install grubby if needed
+  yum:
+    name: "grubby"
+    state: "present"
+  when: ((kernel_unpriv_enable.rc == 1) or (kernel_user_namespace.rc == 1)) and enroot_configure_kernel_options
+
+- name: add kernel options to use enroot
+  command: "grubby --update-kernel={{ enroot_configure_kernel_options_versions }} --args={{ item }}"
+  when: ((kernel_unpriv_enable.rc == 1) or (kernel_user_namespace.rc == 1)) and enroot_configure_kernel_options
+  with_items:
+    - "namespace.unpriv_enable=1"
+    - "user_namespace.enable=1"
+  notify:
+  - reboot node
+

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -61,3 +61,14 @@
   notify:
   - reboot node
 
+- name: set max_user_namespaces 
+  sysctl:
+    name: user.max_user_namespaces
+    value: "{{ enroot_max_user_namespaces }}"
+    state: present
+
+- name: set max_mnt_namespaces
+  sysctl:
+    name: user.max_mnt_namespaces
+    value: "{{ enroot_max_mnt_namespaces }}"
+    state: present


### PR DESCRIPTION
## Summary

For Enroot to work on RHEL-derived systems, the [kernel command line needs to be configured](https://github.com/NVIDIA/enroot/blob/master/doc/requirements.md#kernel-command-line) to correctly enable user namespaces.

This PR enables these kernel command line options if necessary when running on RHEL systems, and reboots the node if we made any changes.

We also add a boolean flag `enroot_configure_kernel_options` that allows us to disable this behavior.

## Test plan

Set up a new CentOS VM and check its kernel command line:

```
[vagrant@localhost ~]$ cat /proc/cmdline
BOOT_IMAGE=/boot/vmlinuz-3.10.0-957.12.2.el7.x86_64 root=UUID=8ac075e3-1124-4bb6-bef7-a6811bf8b870 ro no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop crashkernel=auto LANG=en_US.UTF-8
```

Run the playbook:

```
$ cat playbooks/container/enroot.yml
---
- hosts: all
  become: yes
  roles:
  - ansible-role-enroot

$ ansible-playbook -i virtual/config/inventory -l virtual-mgmt01 playbooks/container/enroot.yml
```

After it completes, note that the node was rebooted:

```
RUNNING HANDLER [ansible-role-enroot : reboot node] *************************************************
changed: [virtual-mgmt01]
```

And check the command line:

```
[vagrant@localhost ~]$ cat /proc/cmdline
BOOT_IMAGE=/boot/vmlinuz-3.10.0-957.12.2.el7.x86_64 root=UUID=8ac075e3-1124-4bb6-bef7-a6811bf8b870 ro no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop crashkernel=auto LANG=en_US.UTF-8 namespace.unpriv_enable=1 user_namespace.enable=1
```

Re-running the playbook correctly skips making changes to the kernel command line.

```
TASK [ansible-role-enroot : check if kernel unpriv enabled] *****************************************
changed: [virtual-mgmt01]

TASK [ansible-role-enroot : check if user namespaces enabled] ***************************************
changed: [virtual-mgmt01]

TASK [ansible-role-enroot : install grubby if needed] **********************************************
skipping: [virtual-mgmt01]

TASK [ansible-role-enroot : add kernel options to use enroot] ****************************************
skipping: [virtual-mgmt01] => (item=namespace.unpriv_enable=1)
skipping: [virtual-mgmt01] => (item=user_namespace.enable=1)
```