### PR TITLE
Fix Enroot upgrade workflow with raw packages from Github

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,14 +5,16 @@ enroot_packages:
   - 'enroot+caps'
 enroot_package_state: present
 enroot_version: "3.2.0"
+enroot_release: "1"
+enroot_version_string: "{{ enroot_version }}-{{ enroot_release }}"
 
 # Install option 1 (default): provide direct URLs to debs or rpms
 enroot_deb_packages:
-  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot_{{ enroot_version }}-1_amd64.deb'
-  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot+caps_{{ enroot_version }}-1_amd64.deb'
+  - 'https://github.com/NVIDIA/enroot/releases/download/v{{ enroot_version }}/enroot_{{ enroot_version_string }}_amd64.deb'
+  - 'https://github.com/NVIDIA/enroot/releases/download/v{{ enroot_version }}/enroot+caps_{{ enroot_version_string }}_amd64.deb'
 enroot_rpm_packages:
-  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot-{{ enroot_version }}-1.el7.x86_64.rpm'
-  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot+caps-{{ enroot_version }}-1.el7.x86_64.rpm'
+  - 'https://github.com/NVIDIA/enroot/releases/download/v{{ enroot_version }}/enroot-{{ enroot_version_string }}.el7.x86_64.rpm'
+  - 'https://github.com/NVIDIA/enroot/releases/download/v{{ enroot_version }}/enroot+caps-{{ enroot_version_string }}.el7.x86_64.rpm'
 
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,14 +4,15 @@ enroot_packages:
   - enroot
   - 'enroot+caps'
 enroot_package_state: present
+enroot_version: "3.2.0"
 
 # Install option 1 (default): provide direct URLs to debs or rpms
 enroot_deb_packages:
-  - 'https://github.com/NVIDIA/enroot/releases/download/v3.2.0/enroot_3.2.0-1_amd64.deb'
-  - 'https://github.com/NVIDIA/enroot/releases/download/v3.2.0/enroot+caps_3.2.0-1_amd64.deb'
+  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot_{{ enroot_version }}-1_amd64.deb'
+  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot+caps_{{ enroot_version }}-1_amd64.deb'
 enroot_rpm_packages:
-  - 'https://github.com/NVIDIA/enroot/releases/download/v3.2.0/enroot-3.2.0-1.el7.x86_64.rpm'
-  - 'https://github.com/NVIDIA/enroot/releases/download/v3.2.0/enroot+caps-3.2.0-1.el7.x86_64.rpm'
+  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot-{{ enroot_version }}-1.el7.x86_64.rpm'
+  - 'https://github.com/NVIDIA/enroot/releases/download/{{ enroot_version }}/enroot+caps-{{ enroot_version }}-1.el7.x86_64.rpm'
 
 epel_package: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -29,12 +29,24 @@
   with_items: "{{ enroot_packages }}"
   when: enroot_rhel_repo is defined
 
-- name: install rpm packages directly if no repo is defined
-  yum:
-    name: "{{ item }}"
-    state: "{{ enroot_package_state }}"
-  with_items: "{{ enroot_rpm_packages }}"
+- name: Correctly install and/or upgrade Enroot packages from rpm
   when: enroot_rhel_repo is not defined
+  block:
+  - name: gather package facts for comparison
+    package_facts:
+      manager: rpm
+  - name: remove existing enroot package if we are changing version
+    yum:
+      name: "{{ enroot_packages }}"
+      state: "absent"
+    when:
+    - "'enroot' in ansible_facts.packages"
+    - "ansible_facts.packages['enroot'][0]['version'] != enroot_version_string"
+  - name: enroot rpm packages
+    yum:
+      name: "{{ item }}"
+      state: "{{ enroot_package_state }}"
+    with_items: "{{ enroot_rpm_packages }}"
 
 - name: check if kernel unpriv enabled
   shell: "cat /proc/cmdline | grep 'namespace.unpriv_enable=1'"

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -16,15 +16,29 @@
     repo: "{{ enroot_ubuntu_repo }}"
   when: enroot_ubuntu_repo is defined
 
-- name: enroot packages
+# We need to do a remove/install dance due to dependency conflicts
+# when installing raw packages from Github
+- name: Correctly install and/or upgrade Enroot packages from deb
+  when: enroot_ubuntu_repo is not defined
+  block:
+  - name: gather package facts for comparison
+    package_facts:
+      manager: apt
+  - name: remove existing enroot package if we are changing version
+    apt:
+      name: "{{ enroot_packages }}"
+      state: "absent"
+    when:
+    - "'enroot' in ansible_facts.packages"
+    - "ansible_facts.packages['enroot'][0]['version'] != enroot_version_string"
+  - name: enroot deb packages
+    apt:
+      deb: "{{ item }}"
+      state: "{{ enroot_package_state }}"
+    with_items: "{{ enroot_deb_packages }}"
+
+- name: Install enroot packages from repos
   apt:
     name: "{{ enroot_packages }}"
     state: "{{ enroot_package_state }}"
   when: enroot_ubuntu_repo is defined
-
-- name: enroot deb packages
-  apt:
-    deb: "{{ item }}"
-    state: "{{ enroot_package_state }}"
-  with_items: "{{ enroot_deb_packages }}"
-  when: enroot_ubuntu_repo is not defined


### PR DESCRIPTION
## Description

Currently the published packages for Enroot, `enroot` and `enroot+caps`, have hard dependencies on the specific versions of the other package.

Unfortunately, when we install package files from the Github directly, these installs take place one at a time. This means that if you attempt to run run this role to perform an upgrade, with an existing enroot package installed, each individual install would lead to the dependencies breaking. This can result in errors like this:

```
TASK [nvidia.enroot : enroot deb packages] ***************************************************************************************************************************************************************************************************
failed: [virtual-login01] (item=https://github.com/NVIDIA/enroot/releases/download/v3.3.1/enroot_3.3.1-1_amd64.deb) => changed=false
  ansible_loop_var: item
  item: https://github.com/NVIDIA/enroot/releases/download/v3.3.1/enroot_3.3.1-1_amd64.deb
  msg: Breaks existing package 'enroot+caps' dependency enroot (= 3.2.0-1)
failed: [virtual-login01] (item=https://github.com/NVIDIA/enroot/releases/download/v3.3.1/enroot+caps_3.3.1-1_amd64.deb) => changed=false
  ansible_loop_var: item
  item: https://github.com/NVIDIA/enroot/releases/download/v3.3.1/enroot+caps_3.3.1-1_amd64.deb
  msg: |-
    Dependency is not satisfiable: enroot (= 3.3.1-1)
```

This PR implements the following workflow for upgrades:

1. Gather package facts
2. Determine if Enroot is already installed, and if so, what the version is
3. If the Enroot version to be installed is different from the existing packages, remove the existing packages
4. Then install the new packages

This PR also implements a convenience variable `enroot_version` to make upgrades easier, rather than having to specify the full URLs.

## Test plan

First, install Enroot using the default version `3.2.0` on a host, e.g.

```
ansible-playbook enroot.yml
```

Where the playbook contains:

```
# enroot.yml
- hosts: all
  become: yes
  roles:
  - nvidia.enroot
```

Then, re-run with a new version specified:

```
ansible-playbook -e '{"enroot_version": "3.3.1"}' enroot.yml
```

And verify the upgrade succeeds.